### PR TITLE
Return ConduitError when Phabricator responds with HTML

### DIFF
--- a/core/call.go
+++ b/core/call.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"strings"
 
 	"github.com/karlseguin/typed"
@@ -45,7 +46,10 @@ func PerformCall(
 
 	jsonBody, err := typed.Json(body)
 	if err != nil {
-		return err
+		return &ConduitError{
+			code: strconv.Itoa(resp.StatusCode),
+			info: string(body),
+		}
 	}
 
 	// parse any error conduit returned first


### PR DESCRIPTION
Sometimes Phabricator Conduit API can respond with HTML error instead of
JSON. For example when MySQL query is terminated due timeout - exception is
thrown. The exception is not handled by Conduit wrapper, errors are not
converted to JSON and HTML page is returned instead. This makes
difficult to investigate what was the actual response from Phab because
conversion from JSON error is returned. Another use case: if web server
(not Phabricator itself) responds with 429 (Too Many Requests) client is
not aware of status code.

This patch handles the situation. HTTP response code is provided as
`code` value of `ConduitError` struct and response body is provided in
`info` field.