### PR TITLE
Introduce basic context.Context compatibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@
 package gonduit
 
 import (
+	"context"
 	"crypto/sha1"
 	"fmt"
 	"io"
@@ -39,12 +40,18 @@ func getAuthSignature(authToken, cert string) string {
 // Connect calls conduit.connect to open an authenticated session for future
 // requests.
 func (c *Conn) Connect() error {
+	return c.ConnectContext(context.Background())
+}
+
+// ConnectContext calls conduit.connect to open an authenticated session for future
+// requests, passing through the given context.
+func (c *Conn) ConnectContext(ctx context.Context) error {
 	authToken := getAuthToken()
 	authSig := getAuthSignature(authToken, c.options.Cert)
 
 	var resp responses.ConduitConnectResponse
 
-	if err := c.Call("conduit.connect", &requests.ConduitConnectRequest{
+	if err := c.CallContext(ctx, "conduit.connect", &requests.ConduitConnectRequest{
 		Client:            c.dialer.ClientName,
 		ClientVersion:     c.dialer.ClientVersion,
 		ClientDescription: c.dialer.ClientDescription,
@@ -76,7 +83,24 @@ func (c *Conn) Call(
 	params interface{},
 	result interface{},
 ) error {
-	return core.PerformCall(
+	ctx := context.Background()
+	return c.CallContext(ctx, method, params, result)
+}
+
+// CallContext allows you to make a raw conduit method call with the given context.
+// Params will be marshalled as JSON and the result JSON will be unmarshalled into
+// the result interface{}.
+//
+// This is primarily useful for calling conduit endpoints that aren't
+// specifically supported by other methods in this package.
+func (c *Conn) CallContext(
+	ctx context.Context,
+	method string,
+	params interface{},
+	result interface{},
+) error {
+	return core.PerformCallContext(
+		ctx,
 		core.GetEndpointURI(c.host, method),
 		params,
 		&result,

--- a/core/call.go
+++ b/core/call.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -15,12 +16,13 @@ func GetEndpointURI(host string, method string) string {
 	return fmt.Sprintf("%s/api/%s", strings.TrimSuffix(host, "/"), method)
 }
 
-// PerformCall performs a call to the Conduit API with the provided URL and
+// PerformCallContext performs a call to the Conduit API with the context, URL and
 // parameters. The response will be unmarshaled into the passed result struct.
 //
 // If an error is encountered, it will be unmarshalled into a ConduitError
 // struct.
-func PerformCall(
+func PerformCallContext(
+	ctx context.Context,
 	endpointURL string,
 	params interface{},
 	result interface{},
@@ -33,7 +35,7 @@ func PerformCall(
 
 	client := makeHTTPClient(options)
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -85,4 +87,19 @@ func PerformCall(
 	}
 
 	return nil
+}
+
+// PerformCall performs a call to the Conduit API with the provided URL and
+// parameters. The response will be unmarshaled into the passed result struct.
+//
+// If an error is encountered, it will be unmarshalled into a ConduitError
+// struct.
+func PerformCall(
+	endpointURL string,
+	params interface{},
+	result interface{},
+	options *ClientOptions,
+) error {
+	ctx := context.Background()
+	return PerformCallContext(ctx, endpointURL, params, result, options)
 }

--- a/dialer.go
+++ b/dialer.go
@@ -1,6 +1,8 @@
 package gonduit
 
 import (
+	"context"
+
 	"github.com/uber/gonduit/core"
 	"github.com/uber/gonduit/responses"
 	"github.com/uber/gonduit/util"
@@ -15,12 +17,19 @@ type Dialer struct {
 
 // Dial connects to conduit and confirms the API capabilities for future calls.
 func Dial(host string, options *core.ClientOptions) (*Conn, error) {
+	ctx := context.Background()
+	return DialContext(ctx, host, options)
+}
+
+// DialContext connects to conduit and confirms the API capabilities for future calls,
+// passing the given context through.
+func DialContext(ctx context.Context, host string, options *core.ClientOptions) (*Conn, error) {
 	var d Dialer
 
 	d.ClientName = "gonduit"
 	d.ClientVersion = "1"
 
-	return d.Dial(host, options)
+	return d.DialContext(ctx, host, options)
 }
 
 // Dial connects to conduit and confirms the API capabilities for future calls.
@@ -28,10 +37,22 @@ func (d *Dialer) Dial(
 	host string,
 	options *core.ClientOptions,
 ) (*Conn, error) {
+	ctx := context.Background()
+	return d.DialContext(ctx, host, options)
+}
+
+// DialContext connects to conduit and confirms the API capabilities for future calls,
+// passing the given context through.
+func (d *Dialer) DialContext(
+	ctx context.Context,
+	host string,
+	options *core.ClientOptions,
+) (*Conn, error) {
 	var res responses.ConduitCapabilitiesResponse
 
 	// We use conduit.connect for authentication and it establishes a session.
-	err := core.PerformCall(
+	err := core.PerformCallContext(
+		ctx,
 		core.GetEndpointURI(host, "conduit.getcapabilities"),
 		nil,
 		&res,


### PR DESCRIPTION
This change set introduces basic `context.Context` compatibility.

Specifically:
- Adds a `ConnectContext` method to `Conn` and defines `Connect` in terms of it.
- Adds a `CallContext` method to `Conn` and defines `Call` in terms of it.
- Adds a `PerformCallContext` function and defines `PerformCall` in terms of it.
- Adds a `DialContext` method to `Dialer` and defines `Dial` in terms of it.
- Adds a `DialContext` function and defines `Dial` in terms of it.

Higher level utility methods such as `ManifestCreateTask` are left unchanged.