### PR TITLE
fix unix timestamp json marshaler bug & add maniphest search response field

### DIFF
--- a/responses/maniphest.go
+++ b/responses/maniphest.go
@@ -111,6 +111,8 @@ type ManiphestSearchResponseItem struct {
 		DateCreated util.UnixTimestamp `json:"dateCreated"`
 		// DateModified is epoch timestamp when the object was last updated.
 		DateModified util.UnixTimestamp `json:"dateModified"`
+		// DateClosed is epoch timestamp when the object was closed.
+		DateClosed util.UnixTimestamp `json:"dateClosed"`
 		// Policy is map of capabilities to current policies.
 		Policy SearchResultPolicy `json:"policy"`
 		// CustomTaskType is custom task type.

--- a/util/time.go
+++ b/util/time.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -12,13 +11,13 @@ type UnixTimestamp time.Time
 
 // MarshalJSON implements the json.Marshaler interface.
 func (t UnixTimestamp) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%d\"", time.Time(t).Unix())), nil
+	return []byte(fmt.Sprintf("%d", time.Time(t).Unix())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (t *UnixTimestamp) UnmarshalJSON(data []byte) (err error) {
 	seconds, err := strconv.Atoi(
-		strings.Trim(string(data), "\\\""),
+		string(data),
 	)
 	if err != nil {
 		return err

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -16,7 +16,7 @@ type TimeTestStruct struct {
 func TestUnixTimestampMarshalJSON(t *testing.T) {
 	now := time.Now()
 
-	expected := fmt.Sprintf("{\"now\":\"%d\"}", now.Unix())
+	expected := fmt.Sprintf("{\"now\":%d}", now.Unix())
 
 	subject := &TimeTestStruct{
 		Now: UnixTimestamp(now),
@@ -31,7 +31,7 @@ func TestUnixTimestampMarshalJSON(t *testing.T) {
 func TestUnixTimestampUnmarshalJSON(t *testing.T) {
 	var subject TimeTestStruct
 
-	err := json.Unmarshal([]byte("{\"now\":\"1445754159\"}"), &subject)
+	err := json.Unmarshal([]byte("{\"now\":1445754159}"), &subject)
 
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1445754159), time.Time(subject.Now).Unix())
@@ -40,7 +40,7 @@ func TestUnixTimestampUnmarshalJSON(t *testing.T) {
 func TestUnixTimestampUnmarshalJSON_withInvalid(t *testing.T) {
 	var subject TimeTestStruct
 
-	err := json.Unmarshal([]byte("{\"now\":\"\"}"), &subject)
+	err := json.Unmarshal([]byte("{\"now\":null}"), &subject)
 
 	assert.NotNil(t, err)
 


### PR DESCRIPTION
I got the following error after calling maniphest search api.
```
[ERR-CONDUIT-CORE: Error while reading "modifiedStart": Expected integer, got something else.]
```