### PR TITLE
Fix json cannot unmarshal string into Go struct field DifferentialRev…

### DIFF
--- a/entities/differential.go
+++ b/entities/differential.go
@@ -16,7 +16,7 @@ type DifferentialRevision struct {
 	DateCreated    util.UnixTimestamp                 `json:"dateCreated"`
 	DateModified   util.UnixTimestamp                 `json:"dateModified"`
 	AuthorPHID     string                             `json:"authorPHID"`
-	Status         constants.DifferentialStatusLegacy `json:"status"`
+	Status         constants.DifferentialStatusLegacy `json:"status,string"`
 	StatusName     string                             `json:"statusName"`
 	Branch         string                             `json:"branch"`
 	Summary        string                             `json:"summary"`


### PR DESCRIPTION
Fix issue that when use `client.DifferentialQuery(*req)` to query the one `differential` details, there was an error as fellow:
```
json:  cannot unmarshal string into Go struct field DifferentialRevision.Status of type constants.DifferentialStatusLegacy
```